### PR TITLE
Dependency & Interp

### DIFF
--- a/src/dfcirrus/modeling/mrf.py
+++ b/src/dfcirrus/modeling/mrf.py
@@ -353,7 +353,7 @@ class MRF_Result:
         from scipy.ndimage import shift
         is_nan = np.isnan(brightstar_models)
         brightstar_models[is_nan] = 0
-        brightstar_models_shifted = shift(np.ma.array(brightstar_models, mask=is_nan), [0.25, 0.25], cval=0.0, order=3, mode='nearest')
+        brightstar_models_shifted = shift(np.ma.array(brightstar_models, mask=is_nan), [0.25, 0.25], cval=0.0, order='bilinear', mode='nearest')
         brightstar_models_shifted[is_nan] = np.nan
         
         return brightstar_models_shifted

--- a/src/dfcirrus/modeling/utils.py
+++ b/src/dfcirrus/modeling/utils.py
@@ -16,6 +16,18 @@ from ..io import logger
 
 def mode(x):
     return 2.5*np.nanmedian(x) - 1.5*np.nanmean(x)
+    
+def circular_region(radius):
+    """ Create a circle of a given radius. Values are NaNs outside of the circle. """
+    xx, yy = np.mgrid[-radius:radius+1, -radius:radius+1]
+
+    r_dist = xx**2. + yy**2.
+    circle = r_dist < radius**2.
+
+    circle = circle.astype(float)
+    circle[np.where(circle == 0.)] = np.nan
+
+    return circle
 
 def background_extraction(field, mask=None, return_rms=True,
                           b_size=64, f_size=3, n_iter=5, **kwargs):
@@ -434,7 +446,6 @@ class RHT_worker:
              kernel_replace_masked=9, use_peak=True,
              normed_by_background=False, bkg=1e5):
         """ Run the RHT and compute the max response. """
-        from fil_finder.rollinghough import circular_region
         from photutils.aperture import RectangularAperture
         
         image, mask = self.image.copy(), self.mask.copy()
@@ -449,7 +460,7 @@ class RHT_worker:
         thetas = np.linspace(0, np.pi, n_theta)
         self.thetas = thetas
 
-        circle, mesh = circular_region(radius)
+        circle = circular_region(radius)
         cen_circle = (circle.shape[1]-1)/2., (circle.shape[0]-1)/2.
 
         line_cube = np.empty((n_theta, circle.shape[0], circle.shape[1]))

--- a/src/dfcirrus/modeling/worker.py
+++ b/src/dfcirrus/modeling/worker.py
@@ -157,7 +157,7 @@ class Worker:
         self.filled_mask = True
         
     
-    def rescale(self, scale=0.25, method='binning',order=1):
+    def rescale(self, scale=0.25, method='binning'):
         """ Rebin the image. Surface brightness is retained. """
         
         from astropy.nddata import block_reduce
@@ -176,10 +176,10 @@ class Worker:
         if method == 'reproject':
             wcs_ds = downsample_wcs(self.wcs, scale=scale)
             shape_out = (int(shape[0]*scale), int(shape[1]*scale))
-            self.image_G, _ = reproject_interp((image_G, self.wcs), wcs_ds, shape_out=shape_out, order=order)
-            self.image_R, _ = reproject_interp((image_R, self.wcs), wcs_ds, shape_out=shape_out, order=order)
+            self.image_G, _ = reproject_interp((image_G, self.wcs), wcs_ds, shape_out=shape_out, order='bilinear')
+            self.image_R, _ = reproject_interp((image_R, self.wcs), wcs_ds, shape_out=shape_out, order='bilinear')
             
-            mask, _ = reproject_interp((self._mask, self.wcs), wcs_ds, shape_out=shape_out, order=order)
+            mask, _ = reproject_interp((self._mask, self.wcs), wcs_ds, shape_out=shape_out, order=1)
             self.mask = mask.astype(bool)
             
         elif method == 'binning':
@@ -490,8 +490,8 @@ class Worker:
             print(f'Downsampling by {scale_factor}...')
             wcs_ds = downsample_wcs(self.wcs, scale=scale_factor)
             shape_out = (int(self._image_shape[0]*scale_factor), int(self._image_shape[1]*scale_factor))
-            img_ref_R_ds, _ = reproject_interp((img_ref_R, self.wcs), wcs_ds, shape_out=shape_out, order=1)
-            img_ref_G_ds, _ = reproject_interp((img_ref_G, self.wcs), wcs_ds, shape_out=shape_out, order=1)
+            img_ref_R_ds, _ = reproject_interp((img_ref_R, self.wcs), wcs_ds, shape_out=shape_out, order='bilinear')
+            img_ref_G_ds, _ = reproject_interp((img_ref_G, self.wcs), wcs_ds, shape_out=shape_out, order='bilinear')
             mask, _ = reproject_interp((self._mask, self.wcs), wcs_ds, shape_out=shape_out, order=1)
             mask = mask.astype(bool)
             
@@ -548,8 +548,8 @@ class Worker:
         # upsampling
         if (scale_factor != None) and (scale_factor<1):
             print(f'Upsampling to original grid...')
-            img_ref_R, _ = reproject_interp((img_ref_R, wcs_ds), self.wcs, shape_out=self._image_shape, order=1)
-            img_ref_G, _ = reproject_interp((img_ref_G, wcs_ds), self.wcs, shape_out=self._image_shape, order=1)
+            img_ref_R, _ = reproject_interp((img_ref_R, wcs_ds), self.wcs, shape_out=self._image_shape, order='bilinear')
+            img_ref_G, _ = reproject_interp((img_ref_G, wcs_ds), self.wcs, shape_out=self._image_shape, order='bilinear')
             
         self.img_ref_R = img_ref_R
         self.img_ref_G = img_ref_G


### PR DESCRIPTION
- Remove fil_finder dependency in cirrus decomposition.
- Use bilinear interpolation.